### PR TITLE
deps: update wazero to v2.0.0 (pre-release)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ on:
       - 'LICENSE'
   pull_request:
 env:
-  GO_VERSION: "1.18"
+  GO_VERSION: "1.20"
   PROTOC_VERSION: "21.12"
 
 jobs:
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         tinygo-version:
-          - "0.26.0"
-          - "0.27.0"
-          - "0.28.1"
+          - "0.31.1"
+          - "0.30.0"
+          - "0.29.0"
 
     steps:
       - uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/planetscale/vtprotobuf v0.4.0
 	github.com/stretchr/testify v1.8.4
-	github.com/tetratelabs/wazero v1.6.1-0.20240308012753-60a670e3ce9f
+	github.com/tetratelabs/wazero v1.2.1
 	google.golang.org/protobuf v1.30.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/planetscale/vtprotobuf v0.4.0
 	github.com/stretchr/testify v1.8.4
-	github.com/tetratelabs/wazero v1.2.1
+	github.com/tetratelabs/wazero v1.6.1-0.20240308012753-60a670e3ce9f
 	google.golang.org/protobuf v1.30.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/knqyf263/go-plugin
 
-go 1.18
+go 1.20
 
 require (
 	github.com/planetscale/vtprotobuf v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/tetratelabs/wazero v1.6.1-0.20240308012753-60a670e3ce9f h1:t83T+wjitObwkGL/7+oESJ/r+3LAnQd+7pnhA3uf908=
-github.com/tetratelabs/wazero v1.6.1-0.20240308012753-60a670e3ce9f/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
+github.com/tetratelabs/wazero v1.2.1 h1:J4X2hrGzJvt+wqltuvcSjHQ7ujQxA9gb6PeMs4qlUWs=
+github.com/tetratelabs/wazero v1.2.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/tetratelabs/wazero v1.2.1 h1:J4X2hrGzJvt+wqltuvcSjHQ7ujQxA9gb6PeMs4qlUWs=
-github.com/tetratelabs/wazero v1.2.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.6.1-0.20240308012753-60a670e3ce9f h1:t83T+wjitObwkGL/7+oESJ/r+3LAnQd+7pnhA3uf908=
+github.com/tetratelabs/wazero v1.6.1-0.20240308012753-60a670e3ce9f/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
This draft updates [wazero](https://wazero.io/) to `main`, and flips the switch to the new advanced optimizing compiler that will be the default in v2.0.0.

Notably, this release introduces new features, such as experimental support to thread spec, and a new compilation pipeline that guarantees increased run-time performance for most workloads: in our tests, this amounts to at least a -30% run-time.